### PR TITLE
Fix error when no types are defined

### DIFF
--- a/wsdl2soaplib
+++ b/wsdl2soaplib
@@ -179,6 +179,7 @@ def get_header(url):
 
 def get_printed_types(service_def_types, standard_type_namespaces):
     # Types
+    type_names = []
     type_map = {}
     type_seq = []
     type_deps = {}
@@ -248,7 +249,8 @@ def get_printed_types(service_def_types, standard_type_namespaces):
 
             types_printed.append((raw_type_name, ''.join(out)))
     types_printed = sort_deps(types_printed, type_deps)
-    type_names, types_printed = zip(*types_printed)
+    if types_printed:
+        type_names, types_printed = zip(*types_printed)
     return type_map, type_seq, type_attributes, list(types_printed), list(type_names)
 
 


### PR DESCRIPTION
If no types are defined in the WSDL file, `zip(*types_printed)` returns an empty list and `type_names, types_printed` will fail at unpacking two values from the empty list.  Adding a check for this case and defining `type_names` as an empty list by default fixes the issue.
